### PR TITLE
add a fast path for constant padding

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -879,6 +879,15 @@ def pad(array, pad_width, mode, **kwargs):
     stat_functions = {"maximum": np.max, "minimum": np.min,
                       "mean": np.mean, "median": np.median}
 
+    if mode == "constant":
+        values = kwargs.get("constant_values", 0)
+        values = _as_pairs(values, array.ndim)
+        if len(set(values)) == 1:
+            # special case: same constant at all boundaries
+            padded, original_area_slice = _pad_simple(array, pad_width,
+                                                      fill_value=values[0][0])
+            return padded
+
     # Create array with final shape and original values
     # (padded area is undefined)
     padded, original_area_slice = _pad_simple(array, pad_width)
@@ -887,8 +896,6 @@ def pad(array, pad_width, mode, **kwargs):
     axes = range(padded.ndim)
 
     if mode == "constant":
-        values = kwargs.get("constant_values", 0)
-        values = _as_pairs(values, padded.ndim)
         for axis, index_pair, value_pair in zip(axes, pad_width, values):
             roi = _view_roi(padded, original_area_slice, axis)
             _set_pad_area(roi, axis, index_pair, value_pair)


### PR DESCRIPTION
Hi @lagru,

I recently came across your PR accelerating `numpy.pad` and think it is very nice.

This PR just has a simpler path for `mode='constant'` when the constant is the same at all boundaries.

I'm not sure to what extent the numpy devs would encourage such special cases, but I thought this one might not be too uncommon.

I did not benchmark in ASV, but here is some output from ipython for a handful of sizes (`pad2` is with the change proposed here):
```Python
x = np.ones((64, ), dtype=np.float32)
%timeit pad(x, 8, mode='constant')
57.2 µs ± 3.3 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit pad2(x, 8, mode='constant')
49.8 µs ± 5.21 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

x = np.ones((64, 64), dtype=np.float32)
%timeit pad(x, 8, mode='constant')
72.5 µs ± 5.22 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit pad2(x, 8, mode='constant')
57.1 µs ± 6.08 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

x = np.ones((64, 64, 64), dtype=np.float32)
%timeit pad(x, 8, mode='constant')
466 µs ± 50 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
%timeit pad2(x, 8, mode='constant')
243 µs ± 524 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)

x = np.ones((64, 64, 64, 64), dtype=np.float32)
%timeit pad(x, 8, mode='constant')
227 ms ± 976 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit pad2(x, 8, mode='constant')
57.6 ms ± 4.29 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

The benefit becomes larger as the size/dimensions increase